### PR TITLE
Document code coverage

### DIFF
--- a/coding-style.md
+++ b/coding-style.md
@@ -511,25 +511,24 @@ displays the status of the individual checks in the pull request.
 
 ### Code Coverage
 
-The GitHub Actions workflow [Analysis][analysis-workflow] contains a _Code
-Coverage_ job that runs unit tests for libvast and bundled plugins, and
+The GitHub Actions workflow [Analysis][analysis-workflow] contains a *Code
+Coverage* job that runs unit tests for libvast and bundled plugins, and
 integration tests for VAST and VAST with bundled plugins to create a detailed
 line coverage report. The CI creates and uploads reports as an artifact in the
 Analysis workflow as part of every pull request and for every merge to master.
 
-Note that a branch being covered does not imply that the tests covering it are
-semantically correct, but the report is still is a valuable indicator
-especially for new tests to see whether a branch is not being tested at all.
-
 In addition to the local report, the workflow uploads the coverage report to
-[Codecov][codecov-vast], which offers a convenient visual interface for seeing
-coverage changes introduced by code changes:
+[Codecov][codecov-vast], which offers a visual interface for seeing coverage
+changes introduced by code changes:
 
 [![Codecov Report][codecov-grid]][codecov-vast]
 
 Each block represents a single file in the project. The size and color of each
 block is represented by the number of statements and the coverage,
 respectively.
+
+Codecov offers also a [sunburst][codecov-sunburst] and [icicle][codecov-icicle]
+graph, visualizing the same data with a different approach.
 
 To generate a coverage report locally, create a new Debug build of VAST with
 the CMake option `-D VAST_ENABLE_CODE_COVERAGE=ON` and run the `ccov` build
@@ -538,3 +537,5 @@ target. This creates a coverage report in `<path/to/build-dir>/ccov`.
 [analysis-workflow]: https://github.com/tenzir/vast/actions/workflows/analysis.yaml
 [codecov-vast]: https://app.codecov.io/gh/tenzir/vast
 [codecov-grid]: https://codecov.io/gh/tenzir/vast/branch/master/graphs/tree.svg?token=T9JgpY4KHO
+[codecov-sunburst]: https://codecov.io/gh/tenzir/vast/branch/master/graphs/sunburst.svg?token=T9JgpY4KHO
+[codecov-icicle]: https://codecov.io/gh/tenzir/vast/branch/master/graphs/sunburst.svg?token=T9JgpY4KHO

--- a/coding-style.md
+++ b/coding-style.md
@@ -531,6 +531,10 @@ Each block represents a single file in the project. The size and color of each
 block is represented by the number of statements and the coverage,
 respectively.
 
+To generate a coverage report locally, create a new Debug build of VAST with
+the CMake option `-D VAST_ENABLE_CODE_COVERAGE=ON` and run the `ccov` build
+target. This creates a coverage report in `<path/to/build-dir>/ccov`.
+
 [analysis-workflow]: https://github.com/tenzir/vast/actions/workflows/analysis.yaml
 [codecov-vast]: https://app.codecov.io/gh/tenzir/vast
 [codecov-grid]: https://codecov.io/gh/tenzir/vast/branch/master/graphs/tree.svg?token=T9JgpY4KHO

--- a/coding-style.md
+++ b/coding-style.md
@@ -508,3 +508,29 @@ When integrating 3rd-party code into the code base, use the following scaffold:
 We use GitHub Actions to build and test each commit. Merging a pull request
 requires that all checks pass for the latest commit in the branch. GitHub
 displays the status of the individual checks in the pull request.
+
+### Code Coverage
+
+The GitHub Actions workflow [Analysis][analysis-workflow] contains a _Code
+Coverage_ job that runs unit tests for libvast and bundled plugins, and
+integration tests for VAST and VAST with bundled plugins to create a detailed
+line coverage report. The CI creates and uploads reports as an artifact in the
+Analysis workflow as part of every pull request and for every merge to master.
+
+Note that a branch being covered does not imply that the tests covering it are
+semantically correct, but the report is still is a valuable indicator
+especially for new tests to see whether a branch is not being tested at all.
+
+In addition to the local report, the workflow uploads the coverage report to
+[Codecov][codecov-vast], which offers a convenient visual interface for seeing
+coverage changes introduced by code changes:
+
+[![Codecov Report][codecov-grid]][codecov-vast]
+
+Each block represents a single file in the project. The size and color of each
+block is represented by the number of statements and the coverage,
+respectively.
+
+[analysis-workflow]: https://github.com/tenzir/vast/actions/workflows/analysis.yaml
+[codecov-vast]: https://app.codecov.io/gh/tenzir/vast
+[codecov-grid]: https://codecov.io/gh/tenzir/vast/branch/master/graphs/tree.svg?token=T9JgpY4KHO


### PR DESCRIPTION
This adds documentation for how to see and interpret code coverage to our guidelines.

I kept this rather minimal for now; once the whole coverage report generation is a bit more stable in CI we can add more content to it.