### PR TITLE
Run prettier on generated docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ export DISCLAIMER
 docs: files lint
 
 lint:
-	@prettier --write "$(DOCS)"
+	@npx prettier --write "$(DOCS)"
 
 destination:
 	@test -d "$(DOCS)" || mkdir -p "$(DOCS)"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ endef
 
 export DISCLAIMER
 
-docs: files
+docs: files lint
+
+lint:
+	@prettier --write "$(DOCS)"
 
 destination:
 	@test -d "$(DOCS)" || mkdir -p "$(DOCS)"


### PR DESCRIPTION
This PR runs `prettier` on the generated docs to avoid linting errors in the [tenzir/docs](https://github.com/tenzir/docs) repo.
